### PR TITLE
[nae] Set referer and origin in header

### DIFF
--- a/api-iife.js
+++ b/api-iife.js
@@ -106,6 +106,19 @@ class CORSFetch {
         ? init.headers
         : Object.entries(init.headers);
 
+      // Some APIs check the referer explicitly like:
+      // https://github.com/8thwall/code8/blob/5c09559cddac355d7587b646ecdafc415bdc8012/reality/cloud/xrhome/src/server/controllers/public-controller.ts#L151
+      // As a safeguard, we force the scheme to be https
+      if (window.location.href) {
+        const referer = window.location.href.replace(/^[a-zA-Z+.-]+:\/\//, 'https://');
+        headers.push(['Referer', referer]);
+      }
+
+      if (window.location.origin) {
+        const origin = window.location.origin.replace(/^[a-zA-Z+.-]+:\/\//, 'https://');
+        headers.push(['Origin', origin]);
+      }
+
       const mappedHeaders = headers.map(([name, val]) => [
         name,
         // we need to ensure we have all values as strings


### PR DESCRIPTION
# Context

When adding the `tauri-plugin-cors-fetch` implementation, I noticed that requests to https://apps.8thwall.com/session-token would fail even with valid `appKey` parameters. This is due to some logic in `public-controller` that was evaluating the origin to an empty string.
```
const origin = parseOrigin(req.get('referer') || req.get('origin')) || ''
```

# Test

Works with hot-reload builds (need to continue iterating on static builds):
`apps/client/nae/loc8-royale/ios/build-install.sh`

Maps load now, when they didn't before:
<img width="332" height="720" alt="image" src="https://github.com/user-attachments/assets/077bb736-b9da-462b-b97e-c474cebc44cf" />
