### PR TITLE
[nae][tauri] Add support for more content-encoding methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,14 @@ http = "1"
 reqwest = { version = "0.12", default-features = false }
 once_cell = "1"
 tokio = { version = "1", features = ["macros"] }
+flate2 = "1.1.2"
+brotli = "8.0.2"
 
 [build-dependencies]
 tauri-plugin = { version = "2", features = ["build"] }
+
+[dev-dependencies]
+httpmock = "0.6"
 
 [features]
 default = [

--- a/src/command_test.rs
+++ b/src/command_test.rs
@@ -1,0 +1,117 @@
+#[cfg(test)]
+mod tests {
+    use crate::commands::{get_response, build_request, RequestConfig};
+    use url::Url;
+    use tokio::sync::oneshot;
+    use flate2::{write::GzEncoder, write::DeflateEncoder, Compression};
+    use brotli::CompressorWriter;
+    use std::io::Write;
+
+    fn encode_gzip(data: &[u8]) -> Vec<u8> {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(data).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    fn encode_deflate(data: &[u8]) -> Vec<u8> {
+        let mut encoder = DeflateEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(data).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    fn encode_brotli(data: &[u8]) -> Vec<u8> {
+        let mut encoder = CompressorWriter::new(Vec::new(), 4096, 5, 22);
+        encoder.write_all(data).unwrap();
+        encoder.into_inner()
+    }
+
+    #[tokio::test]
+    async fn test_get_response_gzip() {
+        use httpmock::MockServer;
+        let server = MockServer::start_async().await;
+        let data = b"hello gzip";
+        let encoded = encode_gzip(data);
+        let mock = server.mock_async(|when, then| {
+            when.method("GET").path("/test_gzip");
+            then.status(200)
+                .header("content-encoding", "gzip")
+                .body(encoded.clone());
+        }).await;
+        let url = Url::parse(&format!("{}test_gzip", server.url("/"))).unwrap();
+        let request_config = RequestConfig::new(
+            1,
+            "GET".to_string(),
+            url,
+            vec![],
+            None,
+            None,
+            None,
+            None,
+        );
+        let request = build_request(request_config).unwrap();
+        let (_tx, rx) = oneshot::channel();
+        let response = get_response(request, rx).await.unwrap();
+        assert_eq!(response.body().as_ref().unwrap(), data);
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_get_response_deflate() {
+        use httpmock::MockServer;
+        let server = MockServer::start_async().await;
+        let data = b"hello deflate";
+        let encoded = encode_deflate(data);
+        let mock = server.mock_async(|when, then| {
+            when.method("GET").path("/test_deflate");
+            then.status(200)
+                .header("content-encoding", "deflate")
+                .body(encoded.clone());
+        }).await;
+        let url = Url::parse(&format!("{}test_deflate", server.url("/"))).unwrap();
+        let request_config = RequestConfig::new(
+            2,
+            "GET".to_string(),
+            url,
+            vec![],
+            None,
+            None,
+            None,
+            None,
+        );
+        let request = build_request(request_config).unwrap();
+        let (_tx, rx) = oneshot::channel();
+        let response = get_response(request, rx).await.unwrap();
+        assert_eq!(response.body().as_ref().unwrap(), data);
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_get_response_brotli() {
+        use httpmock::MockServer;
+        let server = MockServer::start_async().await;
+        let data = b"hello brotli";
+        let encoded = encode_brotli(data);
+        let mock = server.mock_async(|when, then| {
+            when.method("GET").path("/test_brotli");
+            then.status(200)
+                .header("content-encoding", "br")
+                .body(encoded.clone());
+        }).await;
+        let url = Url::parse(&format!("{}test_brotli", server.url("/"))).unwrap();
+        let request_config = RequestConfig::new(
+            3,
+            "GET".to_string(),
+            url,
+            vec![],
+            None,
+            None,
+            None,
+            None,
+        );
+        let request = build_request(request_config).unwrap();
+        let (_tx, rx) = oneshot::channel();
+        let response = get_response(request, rx).await.unwrap();
+        assert_eq!(response.body().as_ref().unwrap(), data);
+        mock.assert_async().await;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ use tauri::{
 pub use error::{Error, Result};
 mod commands;
 mod error;
+#[cfg(test)]
+mod command_test;
 
 pub fn init<R: Runtime>() -> TauriPlugin<R> {
     Builder::<R>::new("cors-fetch")


### PR DESCRIPTION
# Context

Resources with `content-encoding: gzip` were failing to be parsed.

Added support for `gzip`, `deflate`, and `br`

# Test

Tests pass with:
`cargo test --lib`